### PR TITLE
API rename

### DIFF
--- a/python/serial_datagram.py
+++ b/python/serial_datagram.py
@@ -17,7 +17,7 @@ ESC = b'\xDB'
 ESC_END = b'\xDC'
 ESC_ESC = b'\xDD'
 
-def datagram_encode(data):
+def encode(data):
     """
     Encodes the given datagram (bytes object) by adding a CRC at the end then an end marker.
     It also escapes the end marker correctly.
@@ -29,9 +29,9 @@ def datagram_encode(data):
     data = data.replace(END, ESC + ESC_END)
     return data + END
 
-def datagram_decode(data):
+def decode(data):
     """
-    Decodes a datagram. Exact inverse of datagram_encode()
+    Decodes a datagram. Exact inverse of encode()
     """
 
     # Checks if the data is at least long enough for the CRC and the END marker
@@ -50,7 +50,7 @@ def datagram_decode(data):
 
     return data[:-4]
 
-def read_datagram(fd):
+def read(fd):
     """
     Reads a datagram from fd (which is supposed to have one file-like read()
     method).
@@ -66,4 +66,4 @@ def read_datagram(fd):
             return None
 
         if b == END:
-            return datagram_decode(buf)
+            return decode(buf)

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 args = dict(
-    name='serial_datagrams',
+    name='serial_datagram',
     version='0.1',
     description='Transmit datagrams over stream oriented transports',
     packages=['.'],

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 args = dict(
     name='serial_datagram',
-    version='0.1',
+    version='0.2',
     description='Transmit datagrams over stream oriented transports',
     packages=['.'],
     author='CVRA',

--- a/python/tests/test_serial_datagram.py
+++ b/python/tests/test_serial_datagram.py
@@ -1,6 +1,6 @@
 import unittest
 import struct
-from serial_datagrams import *
+import serial_datagram
 from io import BytesIO
 
 class UARTDatagramEncodeTestCase(unittest.TestCase):
@@ -11,7 +11,7 @@ class UARTDatagramEncodeTestCase(unittest.TestCase):
         data = bytes([0] * 3)
         expected_crc = struct.pack('>I', 4282505490)
 
-        datagram = datagram_encode(data)
+        datagram = serial_datagram.encode(data)
         self.assertEqual(expected_crc, datagram[-5:-1], "CRC mismatch")
 
     def test_end_marker(self):
@@ -19,7 +19,7 @@ class UARTDatagramEncodeTestCase(unittest.TestCase):
         Checks that the end marker is added.
         """
         data = bytes([0] * 3)
-        datagram = datagram_encode(data)
+        datagram = serial_datagram.encode(data)
         self.assertEqual(0xc0, datagram[-1], "No end marker")
 
     def test_end_is_replaced(self):
@@ -27,7 +27,7 @@ class UARTDatagramEncodeTestCase(unittest.TestCase):
         Checks that the end byte is escaped.
         """
         data = bytes([0xc0]) # end marker is 0xDB
-        datagram = datagram_encode(data)
+        datagram = serial_datagram.encode(data)
         expected = bytes([0xdb, 0xdc]) # transposed end
 
         self.assertEqual(expected, datagram[0:2], "END was not correctly escaped")
@@ -38,7 +38,7 @@ class UARTDatagramEncodeTestCase(unittest.TestCase):
         """
 
         data = bytes([0xdb]) # esc marker
-        datagram = datagram_encode(data)
+        datagram = serial_datagram.encode(data)
         expected = bytes([0xdb, 0xdd]) # transposed esc
         self.assertEqual(expected, datagram[0:2], "ESC was not correctly escaped")
 
@@ -49,7 +49,7 @@ class UARTDatagramDecodeTestCase(unittest.TestCase):
         """
         datagram = [0,0,0,0xff,0x41,0xd9, 0x12, 0xC0]
         datagram = bytes(datagram)
-        datagram = datagram_decode(datagram)
+        datagram = serial_datagram.decode(datagram)
         self.assertEqual(bytes([0,0,0]), datagram)
 
     def test_invalid_crc_raises_exception(self):
@@ -58,22 +58,22 @@ class UARTDatagramDecodeTestCase(unittest.TestCase):
         """
         datagram = [0,0,0,0xde, 0xad, 0xde, 0xad, 0xC0]
         datagram = bytes(datagram)
-        with self.assertRaises(CRCMismatchError):
-            datagram_decode(datagram)
+        with self.assertRaises(serial_datagram.CRCMismatchError):
+            serial_datagram.decode(datagram)
 
     def test_escape_is_unescaped(self):
         """
         Checks that ESC + ESC_ESC is transformed to ESC.
         """
         datagram = b'\xdb\xdd\xc3\x03\xe4\xd1\xc0'
-        datagram = datagram_decode(datagram)
+        datagram = serial_datagram.decode(datagram)
         self.assertEqual(bytes([0xdb]), datagram)
 
     def test_end_is_unsescaped(self):
         """
         Checks that ESC + ESC_END is transformed to END.
         """
-        datagram = datagram_decode(b'\xdb\xdcIf-=\xc0')
+        datagram = serial_datagram.decode(b'\xdb\xdcIf-=\xc0')
         self.assertEqual(bytes([0xc0]), datagram)
 
     def test_that_weird_sequences_work(self):
@@ -82,9 +82,9 @@ class UARTDatagramDecodeTestCase(unittest.TestCase):
         containing ESC + ESC_END, which would cause a problem if the replace
         happens in the wrong order.
         """
-        data = ESC + ESC_END
-        datagram = datagram_encode(data)
-        self.assertEqual(data, datagram_decode(datagram))
+        data = serial_datagram.ESC + serial_datagram.ESC_END
+        datagram = serial_datagram.encode(data)
+        self.assertEqual(data, serial_datagram.decode(datagram))
 
     def test_that_too_short_sequence_raises_exception(self):
         """
@@ -92,8 +92,8 @@ class UARTDatagramDecodeTestCase(unittest.TestCase):
         an exception.
         """
 
-        with self.assertRaises(FrameError):
-            datagram_decode(bytes([1,2,3,3]))
+        with self.assertRaises(serial_datagram.FrameError):
+            serial_datagram.decode(bytes([1,2,3,3]))
 
 
 class ReadDatagramTestCase(unittest.TestCase):
@@ -101,16 +101,16 @@ class ReadDatagramTestCase(unittest.TestCase):
         """
         Checks if we can read a whole datagram.
         """
-        fd = BytesIO(datagram_encode(bytes([1,2,3])))
-        dt = read_datagram(fd)
+        fd = BytesIO(serial_datagram.encode(bytes([1,2,3])))
+        dt = serial_datagram.read(fd)
         self.assertEqual(dt, bytes([1,2,3]))
 
     def test_what_happens_if_timeout(self):
         """
         Checks that we return None if there was a timeout.
         """
-        data = datagram_encode(bytes([1,2,3]))
+        data = serial_datagram.encode(bytes([1,2,3]))
 
         # Introduce a timeout before receiving the last byte
         fd = BytesIO(data[:-1])
-        self.assertIsNone(read_datagram(fd))
+        self.assertIsNone(serial_datagram.read(fd))


### PR DESCRIPTION
- remove the prefix for the python function names.
- name the python module serial_datagram (without the "s") to be consistent with the C & repo name
